### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,66 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "doppelgangR" in publications use:'
+type: software
+title: 'doppelgangR: Identify likely duplicate samples from genomic or meta-data'
+version: 1.41.0
+doi: 10.1093/jnci/djw146
+abstract: The main function is doppelgangR(), which takes as minimal input a list
+  of ExpressionSet object, and searches all list pairs for duplicated samples. The
+  search is based on the genomic data (exprs(eset)), phenotype/clinical data (pData(eset)),
+  and "smoking guns" - supposedly unique identifiers found in pData(eset).
+authors:
+- family-names: Waldron
+  given-names: Levi
+  email: lwaldron.research@gmail.com
+- family-names: Reister
+  given-names: Markus
+  email: markus.riester@novartis.com
+preferred-citation:
+  type: article
+  title: 'The Doppelganger Effect: Hidden Duplicates in Databases of Transcriptome
+    Profiles'
+  authors:
+  - family-names: Waldron
+    given-names: Levi
+    email: lwaldron.research@gmail.com
+  - family-names: Riester
+    given-names: Markus
+  - family-names: Ramos
+    given-names: Marcel
+  - family-names: Parmigiani
+    given-names: Giovanni
+  - family-names: Birrer
+    given-names: Michael
+  year: '2016'
+  volume: '108'
+  doi: 10.1093/jnci/djw146
+  journal: Journal of the National Cancer Institute
+  start: djw146
+repository: https://bioconductor.org/
+repository-code: https://github.com/lwaldron/doppelgangR
+url: https://waldronlab.github.io/doppelgangR
+date-released: '2025-05-12'
+contact:
+- family-names: Waldron
+  given-names: Levi
+  email: lwaldron.research@gmail.com
+keywords: bioconductor-package
+references:
+- type: manual
+  title: 'doppelgangR: Identify likely duplicate samples from genomic or meta-data'
+  authors:
+  - family-names: Waldron
+    given-names: Levi
+    email: lwaldron.research@gmail.com
+  - family-names: Reister
+    given-names: Markus
+    email: markus.riester@novartis.com
+  year: '2025'
+  notes: R package version 1.41.0
+  url: https://github.com/lwaldron/doppelgangR
+


### PR DESCRIPTION
This automated PR adds or updates `CITATION.cff` using the
[cffr](https://docs.ropensci.org/cffr/) R package (`cffr::cff_write()`).
Citation metadata is derived from the package `DESCRIPTION`, and the
auto-citation is also included as a `references` entry.

## Changes
- **Added / updated** `CITATION.cff` – generated by `cffr::cff_write()` with
  the auto-citation included under `references`

## How citations are handled
- If `inst/CITATION` exists in the repository it is automatically used by
  `cff_write()` as the `preferred-citation` in `CITATION.cff`.
- Otherwise, citation metadata is derived solely from `DESCRIPTION`.
- The auto-citation (equivalent to `citation(".", auto = TRUE)`) is always
  included under the `references` key so that both the preferred and the
  software citation are present.

## Why
A `CITATION.cff` file makes it easy for users and tools (GitHub, Zenodo,
Zotero, etc.) to cite your package correctly.

## Customisation
You can further customise the generated file by editing `CITATION.cff`
directly after this PR is merged. See the
[cffr vignette](https://docs.ropensci.org/cffr/articles/cffr.html) for
details.

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#25884531060](https://github.com/waldronlab/repo-audits/actions/runs/25884531060)).
